### PR TITLE
Get this thing closer to working

### DIFF
--- a/classMemory.ahk
+++ b/classMemory.ahk
@@ -265,8 +265,8 @@ class _ClassMemory
                 ; if script is 64 bit, getModuleBaseAddress() should always work
                 ; if target app is truly 32 bit, then getModuleBaseAddress()
                 ; will work when script is 32 bit
-                if (!this.isTarget64bit) ; Ptr_Size is always 8 in v2
-                    this.BaseAddress := this.getModuleBaseAddress()
+                ; Ptr_Size is always 8 in v2 so this condition would always return true
+                this.BaseAddress := this.getModuleBaseAddress()
                 
 
                 ; If the above failed or wasn't called, fall back to alternate method    


### PR DESCRIPTION
(please squash when merging if doing so)
Fix up a lot of random things to get the whole thing just a bit closer to working.
It at least seems to work for my own purposes, that being getting module addresses and reading/writing numbers to an address and/or pointers. 
Also "fixed" all warning given by the vs code extension. Whether or not they're actual fixes, I dunno, in hindsight I probably should've left the ones that didn't directly affect what I was doing alone. If you want I can go back and undo a lot of them, but as is I'm gonna leave them since otherwise you'd have to click through a lot of warning when starting the script (or just change #Warn I guess...)